### PR TITLE
Skip fly when in 2D Scene View

### DIFF
--- a/Editor/ViewportController.cs
+++ b/Editor/ViewportController.cs
@@ -132,6 +132,8 @@ namespace SpaceNavigatorDriver
 
         static void Fly(SceneView sceneView, Vector3 translationInversion, Vector3 rotationInversion)
         {
+            if (sceneView.in2DMode) return;
+            
             SyncRigWithScene();
 
             // Apply inversion of axes for fly/grabmove mode.


### PR DESCRIPTION
When in 2D scene view to edit a UI a warning is thrown. I have no idea if this is the best way to fix it, but it works and flying makes no sense in 2D so it works for me.

Fixes #30